### PR TITLE
Improve published time on posts

### DIFF
--- a/baza/components/DeteFormatted.tsx
+++ b/baza/components/DeteFormatted.tsx
@@ -38,9 +38,9 @@ export const DateFormatted: FC<{ date: Date }> = ({ date }) => {
                       ? t("intlRelativeTime", {
                           value: daysAgo * -1,
                       })
-                      : (new Date().getUTCHours() - date.getHours()) > 0
-                          ? Math.abs((new Date().getUTCHours() - date.getHours())) + " год."
-                          : Math.abs((new Date().getUTCMinutes() - date.getMinutes())) + " хв."
+                      : (new Date().getHours() - date.getHours()) > 0
+                          ? Math.abs((new Date().getHours() - date.getHours())) + " год."
+                          : Math.abs((new Date().getMinutes() - date.getMinutes())) + " хв."
           }
       </Text>
     </Tooltip>

--- a/baza/components/DeteFormatted.tsx
+++ b/baza/components/DeteFormatted.tsx
@@ -1,5 +1,4 @@
 import { Tooltip, Text } from "@mantine/core";
-import { getTodayInLocale } from "baza/utils/date";
 import { intervalToDuration } from "date-fns";
 import { useState } from "react";
 import { useCallback } from "react";
@@ -7,42 +6,44 @@ import { FC, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 export const DateFormatted: FC<{ date: Date }> = ({ date }) => {
-  const { t } = useTranslation();
-  const [displayFull, setDisplayFull] = useState<boolean>(false);
+    const {t} = useTranslation();
+    const [displayFull, setDisplayFull] = useState<boolean>(false);
 
-  const daysAgo = useMemo(
-    () =>
-      intervalToDuration({
-        start: date,
-        end: new Date(),
-      }).days || 0,
-    [date]
-  );
+    const publishInterval = useMemo(
+        () => {
+            const {days = 0, hours = 0, minutes = 0} =
+                intervalToDuration({
+                    start: date,
+                    end: new Date(),
+                });
+            return {days, hours, minutes};
+        }, [date]
+    );
 
-  const toggleDisplayFull = useCallback(() => {
-    setDisplayFull((displayFull) => !displayFull);
-  }, []);
+    const toggleDisplayFull = useCallback(() => {
+        setDisplayFull((displayFull) => !displayFull);
+    }, []);
 
-  return (
-    <Tooltip label={date.toLocaleString()} openDelay={1000}>
-      <Text
-        sx={{ whiteSpace: "nowrap" }}
-        color="gray"
-        size="sm"
-        onClick={toggleDisplayFull}
-      >
-          {
-              displayFull
-                  ? date.toLocaleString()
-                  : daysAgo > 0
-                      ? t("intlRelativeTime", {
-                          value: daysAgo * -1,
-                      })
-                      : (new Date().getHours() - date.getHours()) > 0
-                          ? Math.abs((new Date().getHours() - date.getHours())) + " год."
-                          : Math.abs((new Date().getMinutes() - date.getMinutes())) + " хв."
-          }
-      </Text>
-    </Tooltip>
-  );
+    return (
+        <Tooltip label={date.toLocaleString()} openDelay={1000}>
+            <Text
+                sx={{whiteSpace: "nowrap"}}
+                color="gray"
+                size="sm"
+                onClick={toggleDisplayFull}
+            >
+                {
+                    displayFull
+                        ? date.toLocaleString()
+                        : publishInterval.days ?? 0 > 0
+                            ? t("intlRelativeTime", {
+                                value: publishInterval.days * -1,
+                            })
+                            : publishInterval.hours > 0
+                                ? publishInterval.hours + " год."
+                                : publishInterval.minutes + " хв."
+                }
+            </Text>
+        </Tooltip>
+    );
 };

--- a/baza/components/DeteFormatted.tsx
+++ b/baza/components/DeteFormatted.tsx
@@ -35,7 +35,7 @@ export const DateFormatted: FC<{ date: Date }> = ({ date }) => {
                 {
                     displayFull
                         ? date.toLocaleString()
-                        : publishInterval.days ?? 0 > 0
+                        : publishInterval.days > 0
                             ? t("intlRelativeTime", {
                                 value: publishInterval.days * -1,
                             })

--- a/baza/components/DeteFormatted.tsx
+++ b/baza/components/DeteFormatted.tsx
@@ -31,13 +31,17 @@ export const DateFormatted: FC<{ date: Date }> = ({ date }) => {
         size="sm"
         onClick={toggleDisplayFull}
       >
-        {displayFull
-          ? date.toLocaleString()
-          : daysAgo > 0
-          ? t("intlRelativeTime", {
-              value: daysAgo * -1,
-            })
-          : getTodayInLocale()}
+          {
+              displayFull
+                  ? date.toLocaleString()
+                  : daysAgo > 0
+                      ? t("intlRelativeTime", {
+                          value: daysAgo * -1,
+                      })
+                      : (new Date().getUTCHours() - date.getHours()) > 0
+                          ? Math.abs((new Date().getUTCHours() - date.getHours())) + " год."
+                          : Math.abs((new Date().getUTCMinutes() - date.getMinutes())) + " хв."
+          }
       </Text>
     </Tooltip>
   );

--- a/baza/components/DeteFormatted.tsx
+++ b/baza/components/DeteFormatted.tsx
@@ -9,7 +9,6 @@ import i18n from "i18next";
 export const DateFormatted: FC<{ date: Date }> = ({ date }) => {
     const {t} = useTranslation();
     const [displayFull, setDisplayFull] = useState<boolean>(false);
-    const rtf = new Intl.RelativeTimeFormat(i18n.language, { style: "short" });
 
     const publishInterval = useMemo(
         () => {
@@ -18,7 +17,16 @@ export const DateFormatted: FC<{ date: Date }> = ({ date }) => {
                     start: date,
                     end: new Date(),
                 });
-            return {days, hours, minutes};
+            
+            const rtf = new Intl.RelativeTimeFormat(i18n.language, { style: "short" });
+            
+            return displayFull
+                ? date.toLocaleString()
+                : days > 0
+                    ? rtf.format(days * -1, "day")
+                    : hours > 0
+                        ? rtf.format(hours * -1, "hour")
+                        : rtf.format(minutes * -1, "minute");
         }, [date]
     );
 
@@ -34,15 +42,7 @@ export const DateFormatted: FC<{ date: Date }> = ({ date }) => {
                 size="sm"
                 onClick={toggleDisplayFull}
             >
-                {
-                    displayFull
-                        ? date.toLocaleString()
-                        : publishInterval.days > 0
-                            ? rtf.format(publishInterval.days * -1, "day")
-                            : publishInterval.hours > 0
-                                ? rtf.format(publishInterval.hours * -1, "hour")
-                                : rtf.format(publishInterval.minutes * -1, "minute")
-                }
+                {publishInterval}
             </Text>
         </Tooltip>
     );

--- a/baza/components/DeteFormatted.tsx
+++ b/baza/components/DeteFormatted.tsx
@@ -4,10 +4,12 @@ import { useState } from "react";
 import { useCallback } from "react";
 import { FC, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import i18n from "i18next";
 
 export const DateFormatted: FC<{ date: Date }> = ({ date }) => {
     const {t} = useTranslation();
     const [displayFull, setDisplayFull] = useState<boolean>(false);
+    const rtf = new Intl.RelativeTimeFormat(i18n.language, { style: "short" });
 
     const publishInterval = useMemo(
         () => {
@@ -36,12 +38,10 @@ export const DateFormatted: FC<{ date: Date }> = ({ date }) => {
                     displayFull
                         ? date.toLocaleString()
                         : publishInterval.days > 0
-                            ? t("intlRelativeTime", {
-                                value: publishInterval.days * -1,
-                            })
+                            ? rtf.format(publishInterval.days * -1, "day")
                             : publishInterval.hours > 0
-                                ? publishInterval.hours + " год."
-                                : publishInterval.minutes + " хв."
+                                ? rtf.format(publishInterval.hours * -1, "hour")
+                                : rtf.format(publishInterval.minutes * -1, "minute")
                 }
             </Text>
         </Tooltip>

--- a/features/post/components/Post.tsx
+++ b/features/post/components/Post.tsx
@@ -135,7 +135,7 @@ export const Post: FC<
                   none: () => creator.name,
                 })}
               />
-              <DateFormatted date={new Date(post.published)} />
+              <DateFormatted date={new Date(post.published + "Z")} />
             </Group>
 
             <Menu withinPortal position="bottom-end" shadow="sm">


### PR DESCRIPTION
display minutes and hours for published time, instead of just "today"
fix hover datetime (time is stored in UTC but was missing 'z')